### PR TITLE
Replace MessageBox with Windows system notifications

### DIFF
--- a/wpf-progressbar-timerkeeper/Constants.cs
+++ b/wpf-progressbar-timerkeeper/Constants.cs
@@ -1,0 +1,82 @@
+// <copyright file="Constants.cs" company="MeterTimeKeeper">
+// Copyright (c) MeterTimeKeeper. All rights reserved.
+// </copyright>
+
+namespace ProgressBarTimerKeeper
+{
+    /// <summary>
+    /// Application constants for UI layout and timing.
+    /// </summary>
+    public static class Constants
+    {
+        /// <summary>
+        /// Timer bar width for vertical positioning.
+        /// </summary>
+        public const double TimerBarWidth = 20;
+
+        /// <summary>
+        /// Timer bar height for horizontal positioning.
+        /// </summary>
+        public const double TimerBarHeight = 20;
+
+        /// <summary>
+        /// Screen size ratio for timer bar length.
+        /// </summary>
+        public const double ScreenSizeRatio = 0.8;
+
+        /// <summary>
+        /// Margin from screen edge.
+        /// </summary>
+        public const double ScreenMargin = 10;
+
+        /// <summary>
+        /// Bottom margin for bottom positioning.
+        /// </summary>
+        public const double BottomMargin = 50;
+
+        /// <summary>
+        /// Expanded width for control panel.
+        /// </summary>
+        public const double ExpandedWidth = 200;
+
+        /// <summary>
+        /// Expanded height for control panel.
+        /// </summary>
+        public const double ExpandedHeight = 150;
+
+        /// <summary>
+        /// Notification display duration in milliseconds.
+        /// </summary>
+        public const int NotificationDuration = 5000;
+
+        /// <summary>
+        /// Notification cleanup delay in milliseconds.
+        /// </summary>
+        public const int NotificationCleanupDelay = 6000;
+
+        /// <summary>
+        /// Progress threshold for orange color.
+        /// </summary>
+        public const double OrangeThreshold = 0.6;
+
+        /// <summary>
+        /// Progress threshold for red color.
+        /// </summary>
+        public const double RedThreshold = 0.8;
+
+        /// <summary>
+        /// Animation duration for blinking effect in milliseconds.
+        /// </summary>
+        public const int BlinkAnimationDuration = 500;
+
+        /// <summary>
+        /// Minimum opacity for blinking animation.
+        /// </summary>
+        public const double BlinkMinOpacity = 0.3;
+
+        /// <summary>
+        /// Maximum opacity for blinking animation.
+        /// </summary>
+        public const double BlinkMaxOpacity = 1.0;
+    }
+}

--- a/wpf-progressbar-timerkeeper/ProgressBarTimerKeeper.csproj
+++ b/wpf-progressbar-timerkeeper/ProgressBarTimerKeeper.csproj
@@ -25,7 +25,6 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.WindowsAPICodePack-Shell" Version="1.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/wpf-progressbar-timerkeeper/ProgressBarTimerKeeper.csproj
+++ b/wpf-progressbar-timerkeeper/ProgressBarTimerKeeper.csproj
@@ -25,6 +25,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.WindowsAPICodePack-Shell" Version="1.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/wpf-progressbar-timerkeeper/TimerWindow.xaml.cs
+++ b/wpf-progressbar-timerkeeper/TimerWindow.xaml.cs
@@ -227,15 +227,20 @@ namespace ProgressBarTimerKeeper
         /// </summary>
         private void ShowTimeUpNotification()
         {
+            // 経過時間を計算
+            int minutes = this.totalSeconds / 60;
+            int seconds = this.totalSeconds % 60;
+            string message = $"時間です！{minutes}分{seconds}秒経過しました！";
+
             try
             {
                 // Windows 10/11のシステム通知を使用
-                this.ShowWindowsNotification("タイマー", "時間切れです！");
+                this.ShowWindowsNotification("タイマー", message);
             }
             catch
             {
                 // フォールバックとしてメッセージボックスを表示
-                System.Windows.MessageBox.Show("時間切れです！", "タイマー", MessageBoxButton.OK, MessageBoxImage.Information);
+                System.Windows.MessageBox.Show(message, "タイマー", MessageBoxButton.OK, MessageBoxImage.Information);
             }
 
             this.MainWindowRequested?.Invoke();


### PR DESCRIPTION
## Summary
- Replace popup MessageBox with native Windows balloon tip notifications when timer expires
- Add fallback to MessageBox if notification system fails
- Update notification message to show elapsed time in format "時間です！X分Y秒経過しました！"

## Test plan
- [ ] Start timer and wait for completion
- [ ] Verify Windows system notification appears instead of popup dialog
- [ ] Verify notification message shows correct elapsed time
- [ ] Test fallback behavior if notification system fails

🤖 Generated with [Claude Code](https://claude.ai/code)